### PR TITLE
Bring back shared library build (pymediainfo needs it)

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,7 +4,7 @@ cmake -G Ninja ^
       -D BUILD_ZLIB=OFF ^
       -D CMAKE_BUILD_TYPE=Release ^
       -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
-      -D BUILD_SHARED_LIBS=OFF ^
+      -D BUILD_SHARED_LIBS=ON ^
       -S Project\CMake ^
       -B build
 if errorlevel 1 exit /b 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - cmake-find-tinyxml2.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 
@@ -33,7 +33,7 @@ test:
     - test -f ${PREFIX}/lib/libmediainfo.dylib  # [osx]
     - test -f ${PREFIX}/lib/libmediainfo.so     # [linux]
     - test -f ${PREFIX}/include/MediaInfo/MediaInfo.h  # [unix]
-    - IF NOT EXIST %LIBRARY_LIB%/MediaInfo.lib exit 1  # [win]
+    - IF NOT EXIST %LIBRARY_BIN%/MediaInfo.dll exit 1  # [win]
     - IF NOT EXIST %LIBRARY_INC%/MediaInfo/MediaInfo.h exit 1  # [win]
 
 about:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This PR brings back DLL generation after a fiasco with pymediainfo.